### PR TITLE
datapack to kubejs

### DIFF
--- a/kubejs/server_scripts/main.js
+++ b/kubejs/server_scripts/main.js
@@ -1,3 +1,0 @@
-// Visit the wiki for more info - https://kubejs.com/
-console.info('Hello, World! (Loaded server example script)')
-

--- a/kubejs/server_scripts/recipes/crafting_shaped.js
+++ b/kubejs/server_scripts/recipes/crafting_shaped.js
@@ -1,0 +1,17 @@
+ServerEvents.recipes(event => {
+    event.shaped(
+        Item.of("cobblemon:healing_machine", 1),
+        [
+            "CGC",
+            "IWI",
+            "IDI"
+        ],
+        {
+            C:"minecraft:copper_ingot",
+            G:"minecraft:ghast_tear",
+            I:"minecraft:iron_ingot",
+            W:"create_cobblemon_potion:medicinal_brew_bucket",
+            D:"minecraft:diamond"
+        }
+    )
+})

--- a/kubejs/server_scripts/recipes/create/crushing.js
+++ b/kubejs/server_scripts/recipes/create/crushing.js
@@ -1,0 +1,44 @@
+ServerEvents.recipes(event => {
+    event.custom({
+        type: "create:crushing",
+        ingredients: [
+            {
+                "item": "create:blaze_burner"
+            }
+        ],
+        processing_time: 150,
+        results: [
+            {
+                "id": "minecraft:blaze_rod"
+            },
+            {
+                "chance": 0.75,
+                "id": "minecraft:blaze_rod"
+            },
+            {
+                "chance": 0.75,
+                "id": "create:experience_nugget"
+            },
+            {
+                "chance": 0.125,
+                "id": "minecraft:iron_ingot"
+            }
+        ]     
+    })
+
+    event.custom({
+        type: "create:crushing",
+        ingredients: [
+            {
+                "item": "minecraft:crying_obsidian"
+            }
+        ],
+        processing_time: 150,
+        results: [
+            {
+                "chance": 0.125,
+                "id": "minecraft:ghast_tear"
+            }
+        ]
+    })
+})

--- a/kubejs/server_scripts/recipes/create/cutting.js
+++ b/kubejs/server_scripts/recipes/create/cutting.js
@@ -1,0 +1,18 @@
+ServerEvents.recipes(event => {
+    event.custom({
+        type: "create:cutting",
+        ingredients: [
+            {
+                "item": "minecraft:purpur_block"
+            }
+        ],
+        processingTime: 200,
+        results: [
+            {
+                "count": 2,
+                "chance": 0.125,
+                "id": "minecraft:shulker_shell"
+            }
+        ]
+    })
+})

--- a/kubejs/server_scripts/recipes/create/haunting.js
+++ b/kubejs/server_scripts/recipes/create/haunting.js
@@ -1,0 +1,19 @@
+
+ServerEvents.recipes(event => {
+    const recipes = [
+        {input:"minecraft:iron_ingot", output:"aether:zanite_gemstone"},
+        {input:"minecraft:ancient_debris", output:"deep_aether:sterling_aercloud"},
+        {input: "minecraft:ender_eye", output:"minecraft:spider_eye"},
+        {input: "minecraft:emerald", output:"deep_aether:skyjade"},
+        {input: "minecraft:diamond", output:"aether:enchanted_gravitite"},
+        {input: "minecraft:coal", output:"aether:ambrosium_shard"},
+
+    ]
+    recipes.forEach((item) => {
+        event.custom({
+            type: "create:haunting",
+            ingredients: [{ "item": item.input }],
+            results: [{ "id": item.output }]
+        })
+    })
+})

--- a/kubejs/server_scripts/recipes/remove_recipes.js
+++ b/kubejs/server_scripts/recipes/remove_recipes.js
@@ -1,0 +1,32 @@
+ServerEvents.recipes(event => {
+    const recipeRemove = [
+        {output: "cobblemon:healing_machine", input: "cobblemon:revive"}
+
+    ]
+    recipeRemove.forEach((recipe) => {
+        event.remove(recipe)
+    })
+
+
+    //? ball eater :)
+    //? Add balls to the list to EXCLUDE from being nuked
+    const ballsToKeep = [
+        "cobblemon:poke_ball",
+        "cobblemon:citrine_ball",
+        "cobblemon:verdant_ball",
+        "cobblemon:azure_ball",
+        "cobblemon:roseate_ball",
+        "cobblemon:slate_ball",
+        "cobblemon:premier_ball",
+        "cobblemon:ancient_poke_ball",
+        "cobblemon:ancient_citrine_ball",
+        "cobblemon:ancient_verdant_ball",
+        "cobblemon:ancient_azure_ball",
+        "cobblemon:ancient_roseate_ball",
+        "cobblemon:ancient_slate_ball",
+        "cobblemon:ancient_ivory_ball",
+        "cobblemon:safari_ball",
+    ]
+    const pattern = new RegExp(`^cobblemon:(?!${ballsToKeep.join('$|')}$).*_ball$`);
+    event.remove({ output: pattern });
+})

--- a/kubejs/server_scripts/recipes/replace_recipes.js
+++ b/kubejs/server_scripts/recipes/replace_recipes.js
@@ -1,0 +1,18 @@
+ServerEvents.recipes(event => {
+    const replacementInput = [
+        {filter: {}, original: "", replaceWith:""}
+    ]
+
+    const replacementOutput = [
+        {filter: {}, original: "", replaceWith:""}
+    ]
+
+    replacementInput.forEach((recipe) => {
+        event.replaceInput(recipe.filter, recipe.original, recipe.replaceWith)
+    })
+
+
+    replacementOutput.forEach((recipe) => {
+        event.replaceOutput(recipe.filter, recipe.original, recipe.replaceWith)
+    })
+})


### PR DESCRIPTION
Ported MagMati datapack recipes over to kubejs.

Other notes:
kubejs seems to warn/error about every compat, just ignore it
replace_recipes warns due to the lists being empty

Other other notes:
seem to be struggling to replace northstar mechanical crafting recipes and seem to be struggling to figure out the event.custom for create:mechanical_crafting
